### PR TITLE
Email removed from signup & trending card alignment fixed

### DIFF
--- a/frontend/src/components/TrendingPostCard.tsx
+++ b/frontend/src/components/TrendingPostCard.tsx
@@ -22,6 +22,7 @@ const baseUrl = import.meta.env.VITE_IMAGE_BASE_URL || "";
 export default function TrendingPostCard({ hazard }: TrendingPostProps) {
   const { user } = useAuth();
 
+  const [expanded, setExpanded] = useState(false);
   const [upvotes, setUpvotes] = useState(hazard.upvotes ?? 0);
   const [upvotedBy, setUpvotedBy] = useState<string[]>(hazard.upvotedBy ?? []);
 
@@ -44,10 +45,10 @@ export default function TrendingPostCard({ hazard }: TrendingPostProps) {
       // update list of users that have upvoted
       setUpvotedBy(updated.upvotedBy);
     } catch (err: any) {
-    const backendMsg = err?.response?.data?.message;
-    toast.error(backendMsg || "Upvote failed");
-    console.error("Upvote failed:", err);
-  }
+      const backendMsg = err?.response?.data?.message;
+      toast.error(backendMsg || "Upvote failed");
+      console.error("Upvote failed:", err);
+    }
   };
 
   return (
@@ -76,7 +77,22 @@ export default function TrendingPostCard({ hazard }: TrendingPostProps) {
             </div>
           </div>
           <div>
-            <p className="text-gray-700 mb-4">{hazard.description}</p>
+            <p
+              className={`text-gray-700 mb-4 text-sm ${
+                expanded ? "" : "line-clamp-2"
+              }`}
+            >
+              {hazard.description}
+            </p>
+
+            {hazard.description.length > 100 && (
+              <button
+                onClick={() => setExpanded(!expanded)}
+                className="text-blue-600 text-sm font-medium hover:underline"
+              >
+                {expanded ? "Read less" : "Read more"}
+              </button>
+            )}
             <div className="flex items-center gap-x-[1rem] overflow-y-hidden">
               {hazard.images && hazard.images.length > 0 ? (
                 <div className="flex gap-2">
@@ -118,13 +134,13 @@ export default function TrendingPostCard({ hazard }: TrendingPostProps) {
           </div>
           <div className="flex items-center justify-between text-gray-600">
             <span className="flex items-center gap-2">
-            <CircleArrowUp
-              onClick={handleUpvote}
-              className={`cursor-pointer transition 
+              <CircleArrowUp
+                onClick={handleUpvote}
+                className={`cursor-pointer transition 
                 ${hasUpvoted ? "text-blue-600" : "text-gray-400"}`}
-            />
-            {`${upvotes} upvotes`}
-          </span>
+              />
+              {`${upvotes} upvotes`}
+            </span>
             {/* <span className="flex items-center gap-2">
               <FaRegCommentDots /> comment
             </span> */}

--- a/frontend/src/pages/signup.tsx
+++ b/frontend/src/pages/signup.tsx
@@ -6,7 +6,7 @@ import { apiSignup } from "../services/auth";
 import { AxiosError } from "axios";
 
 const SignUp: React.FC = () => {
-  const [email, setEmail] = useState<string>("");
+  // const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [confirmPassword, setConfirmPassword] = useState<string>("");
   const [firstName, setFirstName] = useState<string>("");
@@ -27,7 +27,6 @@ const SignUp: React.FC = () => {
       await apiSignup({
         firstName: firstName,
         lastName: lastName,
-        email: email,
         password: password,
         confirmPassword: confirmPassword,
         userName: userName,
@@ -88,7 +87,8 @@ const SignUp: React.FC = () => {
                 required
               />
             </div>
-            <div>
+            {/* email here */}
+            {/* <div>
               <label
                 htmlFor="Email"
                 className="block text-sm font-medium text-gray-700"
@@ -105,7 +105,7 @@ const SignUp: React.FC = () => {
                 placeholder="Enter your email"
                 required
               />
-            </div>
+            </div> */}
             <div>
               <label
                 htmlFor="UserName"

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -8,7 +8,7 @@ export const apiLogin = async (payload: {
 export const apiSignup = async (payload: {
   firstName: string;
   lastName: string;
-  email: string;
+  // email: string;
   password: string;
   confirmPassword: string;
   userName: string;


### PR DESCRIPTION
This PR :
 1. removes email from signup
<img width="433" height="638" alt="Screenshot 2025-12-11 084233" src="https://github.com/user-attachments/assets/1dc0af29-a07b-42aa-a9c5-efb6ccf4b36f" />
 

2. Aligns trending cards properly
<img width="1117" height="471" alt="Screenshot 2025-12-11 083620" src="https://github.com/user-attachments/assets/27f0e1fc-a85c-4fd7-9640-192ae492e252" />


3. Adds a "go-to-home" button on signup and login page
to fix: #123 
and to fix: #122 